### PR TITLE
RSA export parameters should be 'false' for public

### DIFF
--- a/src/SDKs/KeyVault/data-plane/Microsoft.Azure.KeyVault.WebKey.Tests/WebKeySerializationTest.cs
+++ b/src/SDKs/KeyVault/data-plane/Microsoft.Azure.KeyVault.WebKey.Tests/WebKeySerializationTest.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.KeyVault.WebKey.Tests
         {
             RSA rsa = RSA.Create();
 
-            var keyOriginal  = new JsonWebKey(rsa.ExportParameters(true));
+            var keyOriginal  = new JsonWebKey(rsa.ExportParameters(false));
             var keyRecovered = JsonConvert.DeserializeObject<JsonWebKey>(keyOriginal.ToString());
 
             Assert.Equal(keyOriginal, keyRecovered);


### PR DESCRIPTION
You have two tests (public and private) which are identical. I have corrected public test.